### PR TITLE
Release 0.1.2

### DIFF
--- a/lib/rrf/version.rb
+++ b/lib/rrf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RRF
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Version bump to 0.1.2. Protected main requires a PR; the release is then cut via the version-box workflow_dispatch (which no-ops the branch push and pushes only the tag).